### PR TITLE
Fix PyPI package, remove message printed when library is loaded

### DIFF
--- a/adafruit_pcf8591/pcf8591.py
+++ b/adafruit_pcf8591/pcf8591.py
@@ -63,7 +63,6 @@ class PCF8591:
         else:
             raise ValueError("reference_voltage must be from 2.5 - 6.0")
         self._buffer = bytearray(2)
-        print("self.reference_voltage = ", self.reference_voltage)
         # possibly measure each channel here to prep readings for
         # user calls to `read`
 

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
     # simple. Or you can use find_packages().
     # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
     #       CHANGE `py_modules=['...']` TO `packages=['...']`
-    py_modules=["adafruit_pcf8591"],
+    packages=["adafruit_pcf8591"],
 )


### PR DESCRIPTION
Fixes #1.